### PR TITLE
add CofG to sixDoFAccelerationSource

### DIFF
--- a/src/fvModels/derived/sixDoFAccelerationSource/sixDoFAccelerationSource.C
+++ b/src/fvModels/derived/sixDoFAccelerationSource/sixDoFAccelerationSource.C
@@ -141,7 +141,8 @@ Foam::fv::sixDoFAccelerationSource::sixDoFAccelerationSource
         mesh.foundObject<uniformDimensionedVectorField>("g")
       ? dimensionedVector(mesh.lookupObject<uniformDimensionedVectorField>("g"))
       : dimensionedVector("g", dimAcceleration, Zero)
-    )
+    ),
+    CofG ("CofG", dimLength, coeffs().lookupOrDefault<vector>("CofG", Zero))
 {
     readCoeffs();
 }

--- a/src/fvModels/derived/sixDoFAccelerationSource/sixDoFAccelerationSource.H
+++ b/src/fvModels/derived/sixDoFAccelerationSource/sixDoFAccelerationSource.H
@@ -35,6 +35,8 @@ Usage
         type            sixDoFAccelerationSource;
 
         accelerations   <function1>;
+        
+        CofG			(0 0 0);
     }
     \endverbatim
 
@@ -89,7 +91,9 @@ private:
 
         //- Optional gravitational acceleration
         dimensionedVector g_;
-
+        
+        //- Center of gravity
+        dimensionedVector CofG;
 
     // Private Member Functions
 

--- a/src/fvModels/derived/sixDoFAccelerationSource/sixDoFAccelerationSourceTemplates.C
+++ b/src/fvModels/derived/sixDoFAccelerationSource/sixDoFAccelerationSourceTemplates.C
@@ -81,8 +81,8 @@ void Foam::fv::sixDoFAccelerationSource::addSup
     eqn -=
     (
         rho*(2*Omega ^ eqn.psi())         // Coriolis force
-      + rho*(Omega ^ (Omega ^ mesh().C())) // Centrifugal force
-      + rho*(dOmegaDT ^ mesh().C())        // Angular acceleration force
+      + rho*(Omega ^ (Omega ^ (mesh().C()-CofG))) // Centrifugal force
+      + rho*(dOmegaDT ^ (mesh().C()-CofG))        // Angular acceleration force
     );
 }
 


### PR DESCRIPTION
# Description
sixDoFAccelerationSource uses angular velocity and acceleration to calculate "Centrifugal force" and "Angular acceleration force" but it also needs a centre of gravity (or rotation) which was not provided.

# Changes
A vector "CofG" is added to read a location for centre of gravity.
Centrifugal and Angular acceleration forces updated to consider CofG.

# How Has This Been Tested?
the sloshingTank3D tutorial is used to compare following two cases. 
(The amplitude, frequency and CofG of two cases are the same and motion type is roll)
1) Tank has a angular motion (using solidBody/SDA).
2) Mesh is static but the source term (new sixDoFAccelerationSource) is added to case.

![Comp](https://user-images.githubusercontent.com/62381796/143788558-32f6eb61-aa95-4884-a9ba-12ae6c3b8037.png)

It can be concluded that new source term is physical and valid.